### PR TITLE
Update CraftBukkit Versioning utility to Wellspring

### DIFF
--- a/patches/server/0021-Update-CraftBukkit-Versioning-utility-to-Wellspring.patch
+++ b/patches/server/0021-Update-CraftBukkit-Versioning-utility-to-Wellspring.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: bluelhf <blueloveshisfriends@gmail.com>
+Date: Sun, 6 Dec 2020 01:02:31 +0200
+Subject: [PATCH] Update CraftBukkit Versioning utility to Wellspring paths
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
+index 674096cab190d62622f9947853b056f57d43a2a5..de7570f838fece12f9b1793fdeec0bae35d9be02 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
+@@ -11,7 +11,7 @@ public final class Versioning {
+     public static String getBukkitVersion() {
+         String result = "Unknown-Version";
+ 
+-        InputStream stream = Bukkit.class.getClassLoader().getResourceAsStream("META-INF/maven/com.destroystokyo.paper/paper-api/pom.properties");
++        InputStream stream = Bukkit.class.getClassLoader().getResourceAsStream("META-INF/maven/mx.kenzie.wellspring/wellspring-api/pom.properties");
+         Properties properties = new Properties();
+ 
+         if (stream != null) {


### PR DESCRIPTION
## Description
Patches `org.bukkit.craftbukkit.util.Versioning` to use the Wellspring pom.properties one instead of the non-existent Paper one.
This fixes an issue where the API version wasn't reported properly, breaking common plugins like WorldEdit and Essentials.

This pull request closes #1.